### PR TITLE
dd/359/do_with_docker_v5

### DIFF
--- a/pk-test/docker.lua
+++ b/pk-test/docker.lua
@@ -1,0 +1,249 @@
+--------------------------------------------------------------------------------
+-- docker.lua
+-- This file is a part of pk-test library
+-- Copyright (c) pk-test authors (see file COPYRIGHT for the license)
+-- See file `COPYRIGHT` for the license
+--------------------------------------------------------------------------------
+
+require 'lua-nucleo' -- for import()
+
+-- for lfs.chdir(), lfs.currentdir()
+-- lfs pollutes global namespace, so
+-- this is workaround
+local orig_lfs = lfs
+require 'lfs' -- for lfs.chdir(), lfs.currentdir()
+local new_lfs = lfs
+lfs = orig_lfs
+local lfs = new_lfs
+
+-----------------------------------------------------------------------
+
+local shell_exec
+      = import 'lua-aplicado/shell.lua'
+      {
+        'shell_exec'
+      }
+
+local fail
+      = import 'lua-aplicado/error.lua'
+      {
+        'fail'
+      }
+
+local arguments
+      = import 'lua-nucleo/args.lua'
+      {
+        'arguments'
+      }
+
+-----------------------------------------------------------------------
+
+local log, dbg, spam, log_error
+      = import 'lua-aplicado/log.lua' { 'make_loggers' } (
+          'test/docker', 'TDKR'
+        )
+
+-----------------------------------------------------------------------
+
+local log_cwd = function()
+  local res, err = lfs.currentdir()
+  if not res then
+    log_error('lfs.currentdir() failure: ', err)
+    return false
+  end
+  dbg('current work dir is ', res)
+  return true
+end
+
+local change_dir = function(dir)
+  local ok, descr = lfs.chdir(dir)
+  if not ok then
+   log_cwd()
+   log_error('Can not change dir: ', descr)
+   return false
+  end
+  return true
+end
+
+local get_cur_dir = function()
+  local cur_dir, descr = lfs.currentdir()
+  if not cur_dir then
+    log_error('lfs.currentdir() failure: ', descr)
+    return nil, "lfs.currentdir() failure"
+  end
+  return cur_dir
+end
+
+local start_container = function()
+  local status = shell_exec('docker-compose', 'up', '-d')
+  if status ~= 0 then
+    log_cwd()
+    log_error('"docker-compose up -d" returned non-zero value')
+    return false
+  end
+  return true
+end
+
+local stop_container = function()
+  local status = shell_exec('docker-compose', 'down')
+  if status ~= 0 then
+    log_cwd()
+    log_error('"docker-compose down" returned non-zero value')
+    return false
+  end
+  return true
+end
+
+local exec_handler = function(handler)
+  local ok, err = pcall(handler)
+
+  if not ok then
+    pcall(log_error, 'handler has been crashed with error: ', err)
+    return false
+  end
+  return true
+end
+
+-- starts docker container, calls handler, stops container after
+-- handler's end.
+-- function currently crashes with calling error() on
+-- any error.
+-- @return true on success
+local do_with_docker = function (cfg_dir, handler)
+  arguments(
+    'string', cfg_dir,
+    'function', handler
+  )
+
+  log(
+    'do_with_docker() is called with arguments: dir =', cfg_dir,
+    'handler =', handler
+  )
+
+  -- start docker container --
+  log('do_with_docker(): starting docker container')
+  local _, cur_dir = xpcall(
+    get_cur_dir,
+    function()
+      return nil
+    end
+  )
+  if not cur_dir then
+    fail('ddkr_apdir', 'Can not get app current dir')
+  end
+  -- change dir
+  local _, ok = xpcall(
+    function()
+      return change_dir(cfg_dir)
+    end,
+    function()
+      return nil
+    end
+  )
+  if not ok then
+    fail('ddkr_encfg', 'Can not enter cfg dir')
+  end
+  -- start container
+  local _, ok = xpcall(
+    start_container,
+    function()
+      return nil
+    end
+  )
+  if not ok then
+    pcall(change_dir, cur_dir)
+    fail('ddkr_rctnr', 'Can not start container')
+  end
+  -- return to app dir
+  local _, ok = xpcall(
+    function()
+      return change_dir(cur_dir)
+    end,
+    function()
+      return nil
+    end
+  )
+  if not ok then
+    pcall(stop_container)
+    fail('ddkr_apret', 'Can not return to app current dir')
+  end
+
+  -- call handler() --
+  log('do_with_docker(): executing handler()')
+  if not exec_handler(handler) then
+    local _, ok = xpcall(
+      function()
+        return change_dir(cfg_dir)
+      end,
+      function()
+        return nil
+      end
+    )
+    if ok then
+      pcall(stop_container)
+      pcall(change_dir, cur_dir)
+    end
+    fail('ddkr_ehndr', 'handler execution error')
+  end
+
+  -- stop container --
+  log('do_with_docker(): stopping container')
+  local _, cur_dir = xpcall(
+    get_cur_dir,
+    function()
+      return nil
+    end
+  )
+  if not cur_dir then
+    fail('ddkr_adir2', 'Can not get app current dir 2')
+  end
+  -- change to cfg dir
+  local _, ok = xpcall(
+    function()
+      return change_dir(cfg_dir)
+    end,
+    function()
+      return nil
+    end
+  )
+  if not ok then
+    fail('ddkr_ecfg2', 'Can not enter cfg dir 2')
+  end
+  -- stop container
+  local _, ok = xpcall(
+    stop_container,
+    function()
+      return nil
+    end
+  )
+  if not ok then
+    pcall(change_dir, cur_dir)
+    fail('ddkr_tctnr', 'Can not stop container')
+  end
+  -- change to app dir
+  local _, ok = xpcall(
+    function()
+      return change_dir(cur_dir)
+    end,
+    function()
+      return nil
+    end
+  )
+  if not ok then
+    fail('ddkr_aret2', 'Can not return to app current dir 2')
+  end
+
+  return true
+end
+
+return
+{
+  log_cwd = log_cwd;
+  change_dir = change_dir;
+  get_cur_dir = get_cur_dir;
+  stop_container = stop_container;
+  start_container = start_container;
+  exec_handler = exec_handler;
+  do_with_docker = do_with_docker;
+}
+

--- a/test/cases/0030-docker.lua
+++ b/test/cases/0030-docker.lua
@@ -1,0 +1,94 @@
+--------------------------------------------------------------------------------
+-- 0030-docker.lua: tests for pk-test/docker.lua
+-- This file is a part of pk-test library
+-- See file `COPYRIGHT` for the license
+--------------------------------------------------------------------------------
+
+local socket = require 'socket'
+
+local do_with_docker
+      = import 'pk-test/docker.lua'
+      {
+        'do_with_docker'
+      }
+
+local ensure_equals, ensure_fails_with_substring
+      = import 'lua-nucleo/ensure.lua'
+      {
+        'ensure_equals',
+        'ensure_fails_with_substring'
+      }
+
+--------------------------------------------------------------------------------
+
+local CONTAINER_CFG_DIR = 'test/data/echoserv_container5'
+local WRONG_DIR = 'nothing/nowhere/1856916550571289837'
+
+--------------------------------------------------------------------------------
+
+local log, dbg, spam, log_error
+      = import 'lua-aplicado/log.lua' { 'make_loggers' } (
+        "test/docker", "T003"
+      )
+
+--------------------------------------------------------------------------------
+
+local test = (...)('do_with_docker')
+
+--------------------------------------------------------------------------------
+
+test:case 'run-successfull-handler' (function()
+  local handler = function()
+    local a = 1 + 2
+  end
+
+  do_with_docker(CONTAINER_CFG_DIR, handler)
+end)
+
+test:case 'run-handler-which-will-crash' (function()
+  local handler = function()
+    error('forced error')
+  end
+
+  local test = function()
+    do_with_docker(CONTAINER_CFG_DIR, handler)
+  end
+  ensure_fails_with_substring(
+    'handler raises an error',
+    test,
+    'forced error'
+  )
+end)
+
+test:case 'run-docker-with-wrong-dir' (function()
+  local handler = function()
+    local a = 1 + 2
+  end
+
+  local ok, descr = pcall(do_with_docker, WRONG_DIR, handler)
+
+  local test = function()
+    do_with_docker(WRONG_DIR, handler)
+  end
+  ensure_fails_with_substring(
+    'wrong dir raises an error',
+    test,
+    'Can not change dir'
+  )
+end)
+
+test:case 'communicate-with-app-inside-contnr-via-tcp' (function()
+
+  local handler = function()
+    local sock = assert(socket.connect('127.0.0.1', 5000))
+    local msg = 'Lorem ipsum'
+    assert(sock:settimeout(5))
+    assert(sock:send(msg..'\n'))
+    local resp = tostring(assert(sock:receive('*l')))
+    ensure_equals('response from echo matches sent message', resp, msg)
+    assert(sock:close())
+  end
+
+  do_with_docker(CONTAINER_CFG_DIR, handler)
+end)
+

--- a/test/data/echoserv_container5/Dockerfile
+++ b/test/data/echoserv_container5/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu
+EXPOSE 5000:5000/tcp
+STOPSIGNAL SIGINT
+ADD . /code
+WORKDIR /code
+RUN apt-get -y update
+RUN apt-get -y install lua5.1
+RUN apt-get -y install lua-socket
+CMD ["lua", "standalone_echoserv.lua"]
+

--- a/test/data/echoserv_container5/docker-compose.yml
+++ b/test/data/echoserv_container5/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '2'
+services:
+  web:
+    build: .
+    ports:
+     - "5000:5000"
+

--- a/test/data/echoserv_container5/standalone_echoserv.lua
+++ b/test/data/echoserv_container5/standalone_echoserv.lua
@@ -1,0 +1,18 @@
+#!/usr/bin/env lua
+
+socket = require "socket"
+
+local lsock = assert(socket.bind("*", 5000))
+while true do
+  local sock = assert(lsock:accept())
+  local recverr = false
+  while true do
+    local line = sock:receive("*l")
+    if not line then
+      sock:close()
+      break
+    end
+    sock:send(line .. "\n")
+  end
+end
+


### PR DESCRIPTION
same as PR #4  (do_with_docker() feature and it's tests, reformatted according Lua-coding-guidelines) but without devel history

upd:
= no changes in code
= test passes successfully
\* 2 commits -> 3 commits